### PR TITLE
fix(DomProxy): re-observe happens too early

### DIFF
--- a/src/DOM/Proxy.ts
+++ b/src/DOM/Proxy.ts
@@ -261,13 +261,14 @@ export function DomProxy<
                 )
             }
             undoEffects(node)
-            reObserve(false)
             if (node === null || node === undefined) {
                 current = defaultCurrent
+                reObserve(false)
                 if (virtualBefore) virtualBefore.remove()
                 if (virtualAfter) virtualAfter.remove()
             } else {
                 current = node
+                reObserve(false)
                 if (virtualAfter && current instanceof Element) current.after(virtualAfter)
                 if (virtualBefore && current instanceof Element) current.before(virtualBefore)
                 redoEffects()


### PR DESCRIPTION
it's a bugfix PR. Operation `reObserve` should invoke after changed `current` node.