### PR TITLE
fix(mc): missing instanceKey when dispatch event to document

### DIFF
--- a/src/Extension/MessageCenter.ts
+++ b/src/Extension/MessageCenter.ts
@@ -109,7 +109,7 @@ export class MessageCenter<ITypedMessages> {
         }
         if (alsoSendToDocument && typeof document !== 'undefined' && document.dispatchEvent) {
             const event = new CustomEvent(MessageCenterEvent, {
-                detail: await this.serialization.serialization({ data, key }),
+                detail: serialized,
             })
             document.dispatchEvent(event)
         }


### PR DESCRIPTION
MessageCenter requires ALL listeners to exist on the background page to work when crossing env. Not work when sending messages just between tabs.